### PR TITLE
Check CONFIG_RD_GZIP

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -186,4 +186,5 @@ CONFIG_VT			y	# Required for virtual consoles
 CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4
 CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/nemomobile/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.
 CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
+CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
 


### PR DESCRIPTION
This is needed because mer-hybris initrd is gzipped and not all kernels have it https://github.com/mer-hybris/hybris-boot/blob/hybris-10.1/Android.mk#L126