### PR TITLE
Add Kernel Namespace Options for Container Support

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -190,4 +190,7 @@ CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
 CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script
 CONFIG_DEVTMPFS_MOUNT		y	# Required by hybris-boot init-script
 CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Required by hybris, SELinux needs to be disabled. Leave as not set, if you have unset AUDIT (read more about the CONFIG_AUDIT flag)
-
+CONFIG_UTS_NS 			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_IPC_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_PID_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_NET_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers


### PR DESCRIPTION
Kernel Namespaces were enabled in the [Jolla Phone Config](https://together.jolla.com/question/70499/request-fulfilled-enable-container-namespace-features-in-jolla-kernel/) but it seems these were never highlighted in the Mer Kernel Checker script and so ported devices (and perhaps newer Jolla Devices) are missing these options.

The main benefit of these is the ability to run systemd-nspawn containers which could be useful for app process isolation and SFDroid.