### PR TITLE
Remove HOTPLUG from kernel check.

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -165,7 +165,6 @@ CONFIG_UNIX			y	# UNIX sockets option is required to run Mer
 CONFIG_SYSVIPC			y	# Inter Process Communication option is required to run Mer
 CONFIG_EXT4_FS			y,m,!	# Mer uses ext4 as rootfs by default
 CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
-CONFIG_HOTPLUG			y       # systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
 CONFIG_INOTIFY_USER		y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
 CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
 CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended


### PR DESCRIPTION
CONFIG_HOTPLUG is not available for 3.18 and newer kernels.