### PR TITLE
Add CONFIG_NF_NAT_IPV6 in kernel config check.

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -219,4 +219,5 @@ CONFIG_ECRYPT_FS			y,m,!     # optional extra filesystem (ecryptfs)
 CONFIG_F2FS_FS			y,m,!     # optional extra filesystem (f2fs - a good SD filesystem)
 CONFIG_CIFS			y,m,!     # optional extra filesystem (CIFS - Windows net fs)
 CONFIG_BTRFS_FS			y,!     # optional extra filesystem (BTRFS)
+CONFIG_NF_NAT_IPV6		y,m,!	# connman: to enable IPv6 NAT
 


### PR DESCRIPTION
In order to enable IPv6 NAT and the iptables nat table
CONFIG_NF_NAT_IPV6 needs to be enabled in kernel config.
This allows to use IPv6 NAT in connman as well.
See https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV6.html