### PR TITLE
[config] Netfilter conntrack xt match. Contributes to JB#43998

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -137,6 +137,7 @@ CONFIG_NETFILTER_XT_MATCH_NFACCT	y,m,!	# connman (optional): for routing and sta
 CONFIG_NETFILTER_XT_CONNMARK		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
 CONFIG_NETFILTER_XT_TARGET_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
 CONFIG_NETFILTER_XT_MATCH_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK	y	# connman: for iptables conntrack match
 CONFIG_CGROUPS			y       # systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
 CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
 CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html


### PR DESCRIPTION
Netfilter conntrack variables (CONFIG_NETFILTER_XT_MATCH_CONNTRACK)
especially is needed for iptables to function correctly with -m
conntrack.