### PR TITLE
[config] Recommend Audit and SELinux enabled

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -200,7 +200,7 @@ exit $fatal;
 __DATA__
 CONFIG_ANDROID_LOW_MEMORY_KILLER	y,! # Helping memory handling at least with Android runtime (tested on Jolla C)
 CONFIG_ANDROID_PARANOID_NETWORK	y,n       # Since Android 5 on some devices this flag is needed for rild to work. But it breaks connectivity in Sailfish OS if user nemo is not part of inet group. "y,n" switch means that this flag's presence/absence won't fail the checks anymore, but instead dhd will autodetect it and add nemo to inet
-CONFIG_AUDIT			n,!	# This will disable SELinux! That's ok, because hybris adaptations must not have SELinux, but if your device needs its support in kernel, set AUDIT=y and SELINUX_BOOTPARAM=y. Then disable them via kernel cmdline: audit=0 selinux=0. You can also leave audit enabled, if you don't plan to use systemd's containers: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
+CONFIG_AUDIT			y,!	# Required by SELinux. Can be disabled at boottime via kernel cmdline: audit=0. You can also leave audit enabled, if you don't plan to use systemd's containers: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
 CONFIG_AUTOFS4_FS		y,m,!	# systemd (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
 CONFIG_BRIDGE			y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
 CONFIG_CPUSETS			y,m,!	# lxc (optional): required to run lxc containers
@@ -287,7 +287,9 @@ CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/s
 CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
 CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script
 CONFIG_DEVTMPFS_MOUNT		y	# Required by hybris-boot init-script
-CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Required by hybris, SELinux needs to be disabled. Leave as not set, if you have unset AUDIT (read more about the CONFIG_AUDIT flag)
+CONFIG_SECURITY_SELINUX		y,!	# Most hybris adaptations must have SELinux builtin in kernel
+CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Up to hybris-16 it's recommended to have SELinux disabled at boottime via kernel cmdline: selinux=0 or SECURITY_SELINUX_BOOTPARAM_VALUE=0. For hybris-17 SELinux should be left enabled.
+CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE 0,! # Alternative way to disable SELinux at boottime
 CONFIG_UTS_NS 			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
 CONFIG_IPC_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
 CONFIG_PID_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers


### PR DESCRIPTION
Based on #sailfishos-porters activity most new porters use hybris-15/16 base, follow mer-kernel-check advice and set AUDIT=n. This disable SELinux and cause droid-hal-init fail.