### PR TITLE
[config] Replace several renamed or deprecated kernel symbols

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -246,7 +246,8 @@ CONFIG_CGROUP_PERF		y,!	# systemd (optional): https://github.com/systemd/systemd
 CONFIG_CGROUP_SCHED		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_BLK_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NETPRIO_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NETPRIO_CGROUP		y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_NET_PRIO		y,!,>=3.14	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_DEVTMPFS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_DUMMY			n
 CONFIG_FHANDLE			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -232,22 +232,22 @@ CONFIG_IP_NF_MATCH_TTL	y,m,!	# connman: for iptables ttl match
 CONFIG_IP6_NF_MATCH_AH	y,m,!	# connman: for ip6tables ah match
 CONFIG_IP6_NF_MATCH_FRAG	y,m,!	# connman: for ip6tables frag match
 CONFIG_IP6_NF_MATCH_MH	y,m,!	# connman: for ip6tables mh match
-CONFIG_CGROUPS			y       # systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
-CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_CGROUP_CPUACCT		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_CGROUP_MEM_RES_CTLR	y,!,<=3.5	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR_SWAP	y,!,<=3.5	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR_KMEM	y,!,<=3.5	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if kernel version <= 3.5
-CONFIG_MEMCG			y,!,>=3.6	# systemd (optional, but recommended): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if version >= 3.6
-CONFIG_MEMCG_SWAP		y,!,>=3.6	# systemd (optional, but recommended): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if kernel version >= 3.6
-CONFIG_MEMCG_KMEM		y,!,>=3.6	# systemd (optional, but recommended): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html, only valid if kernel version >= 3.6
-CONFIG_CGROUP_PERF		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_CGROUP_SCHED		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_BLK_CGROUP		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_NETPRIO_CGROUP		y,!	# systemd (optional): http://0pointer.de/blog/projects/cgroups-vs-cgroups.html
-CONFIG_DEVTMPFS			y       # systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_CGROUPS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_CPUACCT		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_MEM_RES_CTLR	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR_SWAP	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR_KMEM	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_MEMCG			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if version >= 3.6
+CONFIG_MEMCG_SWAP		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_MEMCG_KMEM		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_CGROUP_PERF		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_SCHED		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_BLK_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NETPRIO_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_DEVTMPFS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_DUMMY			n
 CONFIG_FHANDLE			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474
 CONFIG_SCHEDSTATS		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
@@ -264,23 +264,23 @@ CONFIG_SYSVIPC			y	# Inter Process Communication option is required to run Mer
 CONFIG_EXT4_FS			y,m,!	# Mer uses ext4 as rootfs by default
 CONFIG_CUSE			y,!,>=2.6	# CUSE (optional): Required for software security modules support.
 CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
-CONFIG_INOTIFY_USER		y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
 CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
 CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended
-CONFIG_SIGNALFD			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
-CONFIG_TIMERFD			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
-CONFIG_EPOLL			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_NET			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
-CONFIG_SYSFS			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_SYSFS			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_PROC_FS			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=06d461ee6f3da6650e6d023d7828455752d70b0b
-CONFIG_SYSFS_DEPRECATED		n	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_SYSFS_DEPRECATED		n	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_TMPFS_POSIX_ACL		y	# systemd: required by hybris-boot init-script, if you want pam_systemd.so to setup your "seats". http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
-CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, https://github.com/systemd/systemd/blob/v238/README
 CONFIG_SECCOMP			y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
 CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
-CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
-CONFIG_FW_LOADER_USER_HELPER	n,!	# it's actually needed by some Lollipop based devices; systemd(optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_FW_LOADER_USER_HELPER	n,!	# it's actually needed by some Lollipop based devices; systemd(optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_VT			y	# Required for virtual consoles
 CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4
 CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/nemomobile/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -268,7 +268,7 @@ CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
 CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
 CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
-CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended
+CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not avialable on arm64
 CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
@@ -283,8 +283,8 @@ CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=networ
 CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_FW_LOADER_USER_HELPER	n,!	# it's actually needed by some Lollipop based devices; systemd(optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_VT			y	# Required for virtual consoles
-CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4
-CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/nemomobile/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.
+CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
+CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.
 CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
 CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
 CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -218,7 +218,8 @@ CONFIG_NETFILTER_XT_MATCH_HASHLIMIT	y,m,!	# connman: for iptables hashlimit matc
 CONFIG_NETFILTER_XT_MATCH_IPRANGE	y,m,!	# connman: for iptables iprange match
 CONFIG_NETFILTER_XT_MATCH_MARK	y,m,!	# connman: for iptables mark match
 CONFIG_NETFILTER_XT_MATCH_MULTIPORT	y	# connman: for iptables multiple port match
-CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m	# connman: for iptables owner/qtaguid match
+CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0 # connman: for iptables owner/qtaguid match, deprecated after Android Q, non-mainline feature https://android.googlesource.com/kernel/configs/+/189cbab05f8680af3778b82a0b899485773e42e9%5E%21/android-4.14/android-base.config
+CONFIG_NETFILTER_XT_MATCH_OWNER	y,m,>=4.14.0	# connman: for iptables owner match
 CONFIG_NETFILTER_XT_MATCH_RECENT	y,m,!	# connman: for iptables recent match
 CONFIG_NETFILTER_XT_MATCH_SCTP	y,m,!	# connman: for iptables sctp match
 CONFIG_NETFILTER_XT_MATCH_STATE	y,m,!	# connman: for iptables state match


### PR DESCRIPTION
* [config] RTC_DRV_CMOS and LBDAF doesn't work on ARM64. JB#56192
* [config] NETPRIO_CGROUP is CGROUP_NET_PRIO in 3.14. JB#56192
* [config] Point to readme of systemd version used in SailfishOS