### PR TITLE
[config] Require rfkill feature

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -331,4 +331,5 @@ CONFIG_NAMESPACES		y	# Namespacing is needed by firejail
 CONFIG_UTS_NS			y	# Namespacing option needed by firejail
 CONFIG_IPC_NS			y	# Namespacing option needed by firejail
 CONFIG_PID_NS			y	# Namespacing option needed by firejail
+CONFIG_RFKILL			y,m,!	# Feature rfkill is needed by bluebinder
 


### PR DESCRIPTION
rfkill needs to be enabled because it is used by bluebinder