### PR TITLE
Fix kernel version extraction and enable firmware loader helper

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -270,7 +270,7 @@ CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
 CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
 CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
-CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not avialable on arm64
+CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not available on arm64
 CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
@@ -283,7 +283,8 @@ CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, https://gith
 CONFIG_SECCOMP			y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
 CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
 CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_FW_LOADER_USER_HELPER	n,!	# it's actually needed by some Lollipop based devices; systemd(optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_FW_LOADER_USER_HELPER	y,!	# Required by droid firmware load helper
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,! # optional, for droid firmware load helper
 CONFIG_VT			y	# Required for virtual consoles
 CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
 CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -105,6 +105,7 @@ while (<>) {
       $_ =~ s/#//;
       # Remove extra version number which is separated by + (e.g. Linux/arm 4.4.184+0.0.6)
       $_ =~ tr/+/ /;
+      $_ =~ tr/-/ /;
       $kernel_version = (split(' ', $_, 3))[1];
       print "Kernel version $kernel_version\n" if $debug;
       # Look for values that aren't valid for $kernel_version


### PR DESCRIPTION
Currently kernel version check will fail for: 4.4.184-blah. I do not know perl at all so please update code if there is better way to fix this.