### PR TITLE
Add network related configs, sort and cleanup config list

### DIFF
--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -77,11 +77,13 @@ while (<DATA>) {
 
   my $warning;
   my $version;
+  my $version2;
   # Strip leading/trailing space for each value and check for warnings
   foreach (@allowed) {
     s/^\s+|\s+$//g;
     $warning = 1 if $_ eq "!" ;
-    $version = $_ if m/[\d\.<>=]/;
+    $version2 = $_ if (m/[\d\.<>=]/ and $version);
+    $version = $_ if m/[\d\.<>=]/ and ! $version;
   }
 
   # Each CONFIG_* has an array of allowed values, a comment and a flag
@@ -89,7 +91,8 @@ while (<DATA>) {
   $config{$conf} = {allowed => \@allowed,
                     comment => $comment,
                     warning => $warning,
-                    version => $version};
+                    version => $version,
+                    version2 => $version2};
 }
 
 my $kconfig_line = 0;
@@ -112,9 +115,24 @@ while (<>) {
       for my $conf (keys %config)
       {
          my $c = $config{$conf};
+         my $version_valid = 1;
          if ($c->{"version"})
          {
             my $config_version = $c->{"version"};
+            my $operator = $config_version;
+            $operator =~ s/[\d\s\w\.]//g;
+            $config_version =~ s/[><=]//g;
+            if(!cmp_version($kernel_version, $operator, $config_version))
+            {
+               delete($config{$conf});
+               print "Removing $conf, $kernel_version, $operator, $config_version\n"
+                   if $debug;
+               $version_valid = 0;
+            }
+         }
+         if ($version_valid and $c->{"version2"})
+         {
+            my $config_version = $c->{"version2"};
             my $operator = $config_version;
             $operator =~ s/[\d\s\w\.]//g;
             $config_version =~ s/[><=]//g;

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -203,140 +203,139 @@ CONFIG_ANDROID_LOW_MEMORY_KILLER	y,! # Helping memory handling at least with And
 CONFIG_ANDROID_PARANOID_NETWORK	y,n       # Since Android 5 on some devices this flag is needed for rild to work. But it breaks connectivity in Sailfish OS if user nemo is not part of inet group. "y,n" switch means that this flag's presence/absence won't fail the checks anymore, but instead dhd will autodetect it and add nemo to inet
 CONFIG_AUDIT			y,!	# Required by SELinux. Can be disabled at boottime via kernel cmdline: audit=0. You can also leave audit enabled, if you don't plan to use systemd's containers: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
 CONFIG_AUTOFS4_FS		y,m,!	# systemd (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_BLK_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_BLK_DEV_NBD			y,m,!     # optional, for NFS & CIFS support
 CONFIG_BRIDGE			y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
+CONFIG_BT_BNEP_MC_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_BNEP_PROTO_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_BNEP			y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_HCIUART_H4		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BT_HCIUART		y,!     # Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BT_HCIVHCI		y,!	# Bluez (optional): Needed if bluebinder is used with bluez (Android 8+ based ports)
+CONFIG_BT_HIDP			y,!	# Bluez (optional): Needed for HIDP (Human Interface Device Protocol) transport layer
+CONFIG_BT_MSM_SLEEP		n,!	# Bluez (optional): Causes problems with bluez thus disabling is recommended.
+CONFIG_BT_RFCOMM		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BTRFS_FS			y,!     # optional extra filesystem (BTRFS)
+CONFIG_BT			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_CGROUP_CPUACCT		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_MEM_RES_CTLR_KMEM	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR_SWAP	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_NET_PRIO		y,!,>=3.14	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_PERF		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_SCHED		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUPS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
+CONFIG_CIFS			y,m,!     # optional extra filesystem (CIFS - Windows net fs)
 CONFIG_CPUSETS			y,m,!	# lxc (optional): required to run lxc containers
-CONFIG_IP_NF_TARGET_MASQUERADE	y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
-CONFIG_IP_NF_IPTABLES		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_IP_MULTIPLE_TABLES	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_NETFILTER_NETLINK_ACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_NETFILTER_XT_MATCH_NFACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_NETFILTER_XT_CONNMARK		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
-CONFIG_NETFILTER_XT_TARGET_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
-CONFIG_NETFILTER_XT_MATCH_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
-CONFIG_NETFILTER_XT_MATCH_CONNTRACK	y	# connman: for iptables conntrack match
-CONFIG_NETFILTER_XT_MATCH_DCCP	y,m,!	# connman: for iptables dccp match
-CONFIG_NETFILTER_XT_MATCH_HASHLIMIT	y,m,!	# connman: for iptables hashlimit match
-CONFIG_NETFILTER_XT_MATCH_IPRANGE	y,m,!	# connman: for iptables iprange match
-CONFIG_NETFILTER_XT_MATCH_MARK	y,m,!	# connman: for iptables mark match
-CONFIG_NETFILTER_XT_MATCH_MULTIPORT	y	# connman: for iptables multiple port match
-CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0 # connman: for iptables owner/qtaguid match, deprecated after Android Q, non-mainline feature https://android.googlesource.com/kernel/configs/+/189cbab05f8680af3778b82a0b899485773e42e9%5E%21/android-4.14/android-base.config
-CONFIG_NETFILTER_XT_MATCH_OWNER	y,m,>=4.14.0	# connman: for iptables owner match
-CONFIG_NETFILTER_XT_MATCH_RECENT	y,m,!	# connman: for iptables recent match
-CONFIG_NETFILTER_XT_MATCH_SCTP	y,m,!	# connman: for iptables sctp match
-CONFIG_NETFILTER_XT_MATCH_STATE	y,m,!	# connman: for iptables state match
-CONFIG_NETFILTER_XT_MATCH_PKTTYPE	y,m,!	# connman: for iptables pkttype match
-CONFIG_NETFILTER_XT_MATCH_LIMIT	y,m,!	# connman: for iptables limit match
-CONFIG_NETFILTER_XT_MATCH_HELPER	y,m,!	# connman: for iptables helper match
-CONFIG_NETFILTER_XT_MATCH_ESP	y,m,!	# connmman: for iptables esp match
-CONFIG_IP_NF_MATCH_AH	y,m,!	# connman: for iptables ah match
-CONFIG_IP_NF_MATCH_ECN	y,m,!	# connman: for iptables ecn match
-CONFIG_IP_NF_MATCH_TTL	y,m,!	# connman: for iptables ttl match
+CONFIG_CUSE			y,!,>=2.6	# CUSE (optional): Required for software security modules support.
+CONFIG_DEVTMPFS_MOUNT		y	# Required by hybris-boot init-script
+CONFIG_DEVTMPFS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_DUMMY			n
+CONFIG_ECRYPT_FS			y,m,!     # optional extra filesystem (ecryptfs)
+CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_EXT4_FS			y,m,!	# Mer uses ext4 as rootfs by default
+CONFIG_F2FS_FS_SECURITY		y,m,!     # required to mount f2fs volumes under SELinux
+CONFIG_F2FS_FS			y,m,!     # optional extra filesystem (f2fs - a good SD filesystem)
+CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
+CONFIG_FHANDLE			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,! # optional, for droid firmware load helper
+CONFIG_FW_LOADER_USER_HELPER	y,!	# Required by droid firmware load helper
+CONFIG_HIDRAW			y,m,!	# optional: Support HID devices
+CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script
+CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
 CONFIG_IP6_NF_MATCH_AH	y,m,!	# connman: for ip6tables ah match
 CONFIG_IP6_NF_MATCH_FRAG	y,m,!	# connman: for ip6tables frag match
 CONFIG_IP6_NF_MATCH_MH	y,m,!	# connman: for ip6tables mh match
-CONFIG_CGROUPS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_CPUACCT		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_MEM_RES_CTLR	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR_SWAP	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR_KMEM	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_MEMCG			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if version >= 3.6
-CONFIG_MEMCG_SWAP		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
-CONFIG_MEMCG_KMEM		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
-CONFIG_CGROUP_PERF		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_SCHED		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_BLK_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NETPRIO_CGROUP		y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_NET_PRIO		y,!,>=3.14	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_DEVTMPFS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_DUMMY			n
-CONFIG_FHANDLE			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474
-CONFIG_SCHEDSTATS		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
-CONFIG_SCHED_DEBUG		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
-CONFIG_NLS_UTF8			y	# Ensure that we support UTF8 filenames.
-CONFIG_BT			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_RFCOMM		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_HCIUART		y,!     # Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_HCIUART_H4		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_HCIVHCI		y,!	# Bluez (optional): Needed if bluebinder is used with bluez (Android 8+ based ports)
-CONFIG_BT_HIDP			y,!	# Bluez (optional): Needed for HIDP (Human Interface Device Protocol) transport layer
-CONFIG_BT_BNEP			y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_BNEP_MC_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_BNEP_PROTO_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_MSM_SLEEP		n,!	# Bluez (optional): Causes problems with bluez thus disabling is recommended.
-CONFIG_RFKILL			y,m,!	# (optional) Needed if bluebinder is used
-CONFIG_HIDRAW			y,m,!	# optional: Support HID devices
-CONFIG_UNIX			y	# UNIX sockets option is required to run Mer
-CONFIG_SYSVIPC			y	# Inter Process Communication option is required to run Mer
-CONFIG_EXT4_FS			y,m,!	# Mer uses ext4 as rootfs by default
-CONFIG_CUSE			y,!,>=2.6	# CUSE (optional): Required for software security modules support.
-CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
-CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
-CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
-CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not available on arm64
-CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NET			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
-CONFIG_SYSFS			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_PROC_FS			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=06d461ee6f3da6650e6d023d7828455752d70b0b
-CONFIG_SYSFS_DEPRECATED		n	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_TMPFS_POSIX_ACL		y	# systemd: required by hybris-boot init-script, if you want pam_systemd.so to setup your "seats". http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
-CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, https://github.com/systemd/systemd/blob/v238/README
-CONFIG_SECCOMP			y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
-CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
-CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_FW_LOADER_USER_HELPER	y,!	# Required by droid firmware load helper
-CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,! # optional, for droid firmware load helper
-CONFIG_VT			y	# Required for virtual consoles
-CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
-CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.
-CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
-CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
-CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script
-CONFIG_DEVTMPFS_MOUNT		y	# Required by hybris-boot init-script
-CONFIG_SECURITY_SELINUX		y,!	# Most hybris adaptations must have SELinux builtin in kernel
-CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Up to hybris-16 it's recommended to have SELinux disabled at boottime via kernel cmdline: selinux=0 or SECURITY_SELINUX_BOOTPARAM_VALUE=0. For hybris-17 SELinux should be left enabled.
-CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE 0,! # Alternative way to disable SELinux at boottime
-CONFIG_UTS_NS 			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_IP6_NF_MATCH_RPFILTER	y	# To be able to mitigate CVE-2019-14899 with ConnMan iptables rule
+CONFIG_IPC_NS			y	# Namespacing option needed by firejail
 CONFIG_IPC_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_PID_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_IP_MULTIPLE_TABLES	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_IPTABLES		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_MATCH_AH	y,m,!	# connman: for iptables ah match
+CONFIG_IP_NF_MATCH_ECN	y,m,!	# connman: for iptables ecn match
+CONFIG_IP_NF_MATCH_RPFILTER	y	# Add to have both IPv4 and IPv6 RPFILTER matches set
+CONFIG_IP_NF_MATCH_TTL	y,m,!	# connman: for iptables ttl match
+CONFIG_IP_NF_TARGET_MASQUERADE	y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
+CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
+CONFIG_ISO9660_FS			y,m,!     # optional extra filesystem (CD-ROM)
+CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
+CONFIG_LOCKD_V4			y,!     # optional, for NFS support
+CONFIG_LOCKD			y,m,!     # optional, for NFS support
+CONFIG_MEMCG_KMEM		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_MEMCG_SWAP		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_MEMCG			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if version >= 3.6
+CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
+CONFIG_NAMESPACES		y	# Namespacing is needed by firejail
+CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NETFILTER_NETLINK_ACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_NETFILTER_XT_CONNMARK		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
+CONFIG_NETFILTER_XT_MATCH_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK	y	# connman: for iptables conntrack match
+CONFIG_NETFILTER_XT_MATCH_DCCP	y,m,!	# connman: for iptables dccp match
+CONFIG_NETFILTER_XT_MATCH_ESP	y,m,!	# connmman: for iptables esp match
+CONFIG_NETFILTER_XT_MATCH_HASHLIMIT	y,m,!	# connman: for iptables hashlimit match
+CONFIG_NETFILTER_XT_MATCH_HELPER	y,m,!	# connman: for iptables helper match
+CONFIG_NETFILTER_XT_MATCH_IPRANGE	y,m,!	# connman: for iptables iprange match
+CONFIG_NETFILTER_XT_MATCH_LIMIT	y,m,!	# connman: for iptables limit match
+CONFIG_NETFILTER_XT_MATCH_MARK	y,m,!	# connman: for iptables mark match
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT	y	# connman: for iptables multiple port match
+CONFIG_NETFILTER_XT_MATCH_NFACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_NETFILTER_XT_MATCH_OWNER	y,m,>=4.14.0	# connman: for iptables owner match
+CONFIG_NETFILTER_XT_MATCH_PKTTYPE	y,m,!	# connman: for iptables pkttype match
+CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0 # connman: for iptables owner/qtaguid match, deprecated after Android Q, non-mainline feature https://android.googlesource.com/kernel/configs/+/189cbab05f8680af3778b82a0b899485773e42e9%5E%21/android-4.14/android-base.config
+CONFIG_NETFILTER_XT_MATCH_RECENT	y,m,!	# connman: for iptables recent match
+CONFIG_NETFILTER_XT_MATCH_SCTP	y,m,!	# connman: for iptables sctp match
+CONFIG_NETFILTER_XT_MATCH_STATE	y,m,!	# connman: for iptables state match
+CONFIG_NETFILTER_XT_TARGET_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
 CONFIG_NET_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_SECURITY_YAMA		y,!     # optional, prevents user's processes from ptracing each other
-CONFIG_SECURITY_YAMA_STACKED	y,!,<4.3     # optional, only valid for kernel < 4.3
+CONFIG_NETPRIO_CGROUP		y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_NETWORK_FILESYSTEMS	y,!     # optional, for NFS support
-CONFIG_NFS_FS			y,m,!     # optional, for NFS support
-CONFIG_NFS_V3			y,!     # optional, for NFS support
-CONFIG_NFS_V3_ACL		y,!     # optional, for NFS support
-CONFIG_NFS_V4			y,!     # optional, for NFS support
-CONFIG_NFS_V4_1			y,!     # optional, for NFS support
-CONFIG_NFS_USE_KERNEL_DNS	y,!     # optional, for NFS support
+CONFIG_NET			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
+CONFIG_NF_NAT_IPV6		y,m,!	# connman: to enable IPv6 NAT
 CONFIG_NFS_ACL_SUPPORT		y,m,!     # optional, for NFS support
 CONFIG_NFS_COMMON			y,!     # optional, for NFS support
-CONFIG_LOCKD			y,m,!     # optional, for NFS support
-CONFIG_LOCKD_V4			y,!     # optional, for NFS support
-CONFIG_SUNRPC			y,m,!     # optional, for NFS support
-CONFIG_SUNRPC_GSS			y,m,!     # optional, for NFS support
-CONFIG_BLK_DEV_NBD			y,m,!     # optional, for NFS & CIFS support
-CONFIG_ISO9660_FS			y,m,!     # optional extra filesystem (CD-ROM)
-CONFIG_UDF_FS			y,m,!     # optional extra filesystem (DVD & portable USB)
-CONFIG_ECRYPT_FS			y,m,!     # optional extra filesystem (ecryptfs)
-CONFIG_F2FS_FS			y,m,!     # optional extra filesystem (f2fs - a good SD filesystem)
-CONFIG_F2FS_FS_SECURITY		y,m,!     # required to mount f2fs volumes under SELinux
-CONFIG_CIFS			y,m,!     # optional extra filesystem (CIFS - Windows net fs)
-CONFIG_BTRFS_FS			y,!     # optional extra filesystem (BTRFS)
-CONFIG_IP_NF_MATCH_RPFILTER	y	# Add to have both IPv4 and IPv6 RPFILTER matches set
-CONFIG_IP6_NF_MATCH_RPFILTER	y	# To be able to mitigate CVE-2019-14899 with ConnMan iptables rule
-CONFIG_NF_NAT_IPV6		y,m,!	# connman: to enable IPv6 NAT
-CONFIG_QUOTA			y	# Quota is needed to prevent additional users from taking all space
+CONFIG_NFS_FS			y,m,!     # optional, for NFS support
+CONFIG_NFS_USE_KERNEL_DNS	y,!     # optional, for NFS support
+CONFIG_NFS_V3_ACL		y,!     # optional, for NFS support
+CONFIG_NFS_V3			y,!     # optional, for NFS support
+CONFIG_NFS_V4_1			y,!     # optional, for NFS support
+CONFIG_NFS_V4			y,!     # optional, for NFS support
+CONFIG_NLS_UTF8			y	# Ensure that we support UTF8 filenames.
+CONFIG_PID_NS			y	# Namespacing option needed by firejail
+CONFIG_PID_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_PROC_FS			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=06d461ee6f3da6650e6d023d7828455752d70b0b
+CONFIG_QFMT_V2			y	# Use this version of the interface for quotactl
 CONFIG_QUOTACTL			y	# To adjust quota
 CONFIG_QUOTA_NETLINK_INTERFACE	y	# For quota_nld service
-CONFIG_QFMT_V2			y	# Use this version of the interface for quotactl
-CONFIG_NAMESPACES		y	# Namespacing is needed by firejail
+CONFIG_QUOTA			y	# Quota is needed to prevent additional users from taking all space
+CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
+CONFIG_RFKILL			y,m,!	# (optional) Needed if bluebinder is used
+CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not available on arm64
+CONFIG_SCHED_DEBUG		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
+CONFIG_SCHEDSTATS		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
+CONFIG_SECCOMP			y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
+CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE 0,! # Alternative way to disable SELinux at boottime
+CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Up to hybris-16 it's recommended to have SELinux disabled at boottime via kernel cmdline: selinux=0 or SECURITY_SELINUX_BOOTPARAM_VALUE=0. For hybris-17 SELinux should be left enabled.
+CONFIG_SECURITY_SELINUX		y,!	# Most hybris adaptations must have SELinux builtin in kernel
+CONFIG_SECURITY_YAMA_STACKED	y,!,<4.3     # optional, only valid for kernel < 4.3
+CONFIG_SECURITY_YAMA		y,!     # optional, prevents user's processes from ptracing each other
+CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SUNRPC_GSS			y,m,!     # optional, for NFS support
+CONFIG_SUNRPC			y,m,!     # optional, for NFS support
+CONFIG_SYSFS_DEPRECATED		n	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SYSFS			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SYSVIPC			y	# Inter Process Communication option is required to run Mer
+CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_TMPFS_POSIX_ACL		y	# systemd: required by hybris-boot init-script, if you want pam_systemd.so to setup your "seats". http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
+CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, https://github.com/systemd/systemd/blob/v238/README
+CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
+CONFIG_UDF_FS			y,m,!     # optional extra filesystem (DVD & portable USB)
+CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_UNIX			y	# UNIX sockets option is required to run Mer
 CONFIG_UTS_NS			y	# Namespacing option needed by firejail
-CONFIG_IPC_NS			y	# Namespacing option needed by firejail
-CONFIG_PID_NS			y	# Namespacing option needed by firejail
-
+CONFIG_UTS_NS 			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_VT			y	# Required for virtual consoles
+CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -263,22 +263,43 @@ CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,!	# optional, for droid firmware load he
 CONFIG_FW_LOADER_USER_HELPER		y,!	# Required by droid firmware load helper
 CONFIG_HIDRAW				y,m,!	# optional: Support HID devices
 CONFIG_IKCONFIG_PROC			y	# Required by hybris-boot init-script
+CONFIG_INET_AH				y	# Required by IPSec
+CONFIG_INET_ESP				y	# Required by IPSec
+CONFIG_INET6_AH				y	# Required by IPSec
+CONFIG_INET6_ESP			y	# Required by IPSec
 CONFIG_INOTIFY_USER			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_IP6_NF_FILTER			y,m	# Basic IPv6 packet filtering support for netfilter
+CONFIG_IP6_NF_IPTABLES			y,m	# Basic IPv6 iptables support for packet filtering
+CONFIG_IP6_NF_MANGLE			y,m	# Support IPv6 packet mangling with netfilter
 CONFIG_IP6_NF_MATCH_AH			y,m,!	# connman: for ip6tables ah match
 CONFIG_IP6_NF_MATCH_FRAG		y,m,!	# connman: for ip6tables frag match
 CONFIG_IP6_NF_MATCH_MH			y,m,!	# connman: for ip6tables mh match
 CONFIG_IP6_NF_MATCH_RPFILTER		y	# To be able to mitigate CVE-2019-14899 with ConnMan iptables rule
+CONFIG_IP6_NF_RAW			y	# Support RAW packet table in IPv6 netfilter. A basic need for iptables.
+CONFIG_IP6_NF_TARGET_REJECT		y	# Support netfilter reject target in IPv6 netfilter. A basic need for iptables.
 CONFIG_IPC_NS				y	# Namespacing option needed by firejail
 CONFIG_IPC_NS				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
 CONFIG_IP_MULTIPLE_TABLES		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_ARPFILTER			y,m,!	# Support filtering arp packets in netfilter
+CONFIG_IP_NF_ARP_MANGLE			y,m,!	# Support mangling of ARP packets in netfilter
+CONFIG_IP_NF_ARPTABLES			y,m,!	# Support ARP tables in netfilter
+CONFIG_IP_NF_FILTER			y	# Support packet filtering in IPv4 netfilter
 CONFIG_IP_NF_IPTABLES			y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_MANGLE			y	# Support mangle table in IPV4 netfilter. Mangle table is required for IPv6 CVE-2019-14899
 CONFIG_IP_NF_MATCH_AH			y,m,!	# connman: for iptables ah match
 CONFIG_IP_NF_MATCH_ECN			y,m,!	# connman: for iptables ecn match
 CONFIG_IP_NF_MATCH_RPFILTER		y	# Add to have both IPv4 and IPv6 RPFILTER matches set
 CONFIG_IP_NF_MATCH_TTL			y,m,!	# connman: for iptables ttl match
+CONFIG_IP_NF_NAT			y,>=3.17	# Support NAT table in netfilter. Tethering requires this. Since 3.17 and before this as CONFIG_NF_NAT_IPV4
+CONFIG_IP_NF_RAW			y	# Support raw table in IPv4 netfilter
+CONFIG_IP_NF_SECURITY			y	# Support security table in IPv4 netfilter
 CONFIG_IP_NF_TARGET_MASQUERADE		y,m,!	# connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
+CONFIG_IP_NF_TARGET_REDIRECT		y,m,!	# Support redirect target in IPv4 netfilter, required for some masquerading scenarios
+CONFIG_IP_NF_TARGET_REJECT		y	# Support reject target in IPv4 netfilter, a quite basic requirement for iptables
+CONFIG_IP_SCTP				y,!,>=3.8	# SCTP support on both IP families, experimental exists already from 2.5 upwards but android kernels may have broken support for it. Experimental status dropped on 3.8 and upwards.
 CONFIG_IPV6				y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
 CONFIG_ISO9660_FS			y,m,!	# optional extra filesystem (CD-ROM)
+CONFIG_L2TP_IP				y,m,!	# Support for L2TP-over-IP socket family. Enables L2TPIP socket family with which userspace L2TPv3 daemons may create L2TP/IP tunnel sockets when UDP encapsulation is not required
 CONFIG_LBDAF				y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
 CONFIG_LOCKD_V4				y,!	# optional, for NFS support
 CONFIG_LOCKD				y,m,!	# optional, for NFS support
@@ -307,12 +328,17 @@ CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0	# connman: for iptables owner/qta
 CONFIG_NETFILTER_XT_MATCH_RECENT	y,m,!	# connman: for iptables recent match
 CONFIG_NETFILTER_XT_MATCH_SCTP		y,m,!	# connman: for iptables sctp match
 CONFIG_NETFILTER_XT_MATCH_STATE		y,m,!	# connman: for iptables state match
+CONFIG_NETFILTER_XT_NAT			y,m,!	# Enable netfilter DNAT and SNAT targets.
 CONFIG_NETFILTER_XT_TARGET_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
+CONFIG_NETFILTER_XT_TARGET_LOG		y,m,!	# Enable LOG target for netfilter. A real basic need for debugging iptables rules.
 CONFIG_NET_NS				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
 CONFIG_NETPRIO_CGROUP			y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
 CONFIG_NETWORK_FILESYSTEMS		y,!	# optional, for NFS support
 CONFIG_NET				y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
-CONFIG_NF_NAT_IPV6			y,m,!	# connman: to enable IPv6 NAT
+CONFIG_NF_CONNTRACK_IPV4		y,m,!,<=4.18	# optional, exists up to 4.18
+CONFIG_NF_CONNTRACK_IPV6		y,m,!,<=4.18	# optional, exists up to 4.18
+CONFIG_NF_NAT_IPV4			y,m,>=3.7,<=5.0	# connman: to enable IPv4 NAT, exists in kernels betweek 3.7 and 5.0
+CONFIG_NF_NAT_IPV6			y,m,!,>=3.7,<=5.0	# connman: to enable IPv6 NAT, optional as exists in kernel between 3.7 to 5.0
 CONFIG_NFS_ACL_SUPPORT			y,m,!	# optional, for NFS support
 CONFIG_NFS_COMMON			y,!	# optional, for NFS support
 CONFIG_NFS_FS				y,m,!	# optional, for NFS support

--- a/mer_verify_kernel_config
+++ b/mer_verify_kernel_config
@@ -200,142 +200,142 @@ exit $fatal;
 
 __DATA__
 CONFIG_ANDROID_LOW_MEMORY_KILLER	y,! # Helping memory handling at least with Android runtime (tested on Jolla C)
-CONFIG_ANDROID_PARANOID_NETWORK	y,n       # Since Android 5 on some devices this flag is needed for rild to work. But it breaks connectivity in Sailfish OS if user nemo is not part of inet group. "y,n" switch means that this flag's presence/absence won't fail the checks anymore, but instead dhd will autodetect it and add nemo to inet
-CONFIG_AUDIT			y,!	# Required by SELinux. Can be disabled at boottime via kernel cmdline: audit=0. You can also leave audit enabled, if you don't plan to use systemd's containers: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
-CONFIG_AUTOFS4_FS		y,m,!	# systemd (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
-CONFIG_BLK_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_BLK_DEV_NBD			y,m,!     # optional, for NFS & CIFS support
-CONFIG_BRIDGE			y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
-CONFIG_BT_BNEP_MC_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_BNEP_PROTO_FILTER	y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_BNEP			y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
-CONFIG_BT_HCIUART_H4		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_HCIUART		y,!     # Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BT_HCIVHCI		y,!	# Bluez (optional): Needed if bluebinder is used with bluez (Android 8+ based ports)
-CONFIG_BT_HIDP			y,!	# Bluez (optional): Needed for HIDP (Human Interface Device Protocol) transport layer
-CONFIG_BT_MSM_SLEEP		n,!	# Bluez (optional): Causes problems with bluez thus disabling is recommended.
-CONFIG_BT_RFCOMM		y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_BTRFS_FS			y,!     # optional extra filesystem (BTRFS)
-CONFIG_BT			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
-CONFIG_CGROUP_CPUACCT		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_DEVICE		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_FREEZER		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_MEM_RES_CTLR_KMEM	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR_SWAP	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_CGROUP_MEM_RES_CTLR	y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
-CONFIG_CGROUP_NET_PRIO		y,!,>=3.14	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_PERF		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUP_SCHED		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CGROUPS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_CHECKPOINT_RESTORE	y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
-CONFIG_CIFS			y,m,!     # optional extra filesystem (CIFS - Windows net fs)
-CONFIG_CPUSETS			y,m,!	# lxc (optional): required to run lxc containers
-CONFIG_CUSE			y,!,>=2.6	# CUSE (optional): Required for software security modules support.
-CONFIG_DEVTMPFS_MOUNT		y	# Required by hybris-boot init-script
-CONFIG_DEVTMPFS			y       # systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_DUMMY			n
-CONFIG_ECRYPT_FS			y,m,!     # optional extra filesystem (ecryptfs)
-CONFIG_EPOLL			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_EXT4_FS			y,m,!	# Mer uses ext4 as rootfs by default
-CONFIG_F2FS_FS_SECURITY		y,m,!     # required to mount f2fs volumes under SELinux
-CONFIG_F2FS_FS			y,m,!     # optional extra filesystem (f2fs - a good SD filesystem)
-CONFIG_FANOTIFY			y,!	# optional, required for systemd readahead.
-CONFIG_FHANDLE			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474
-CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,! # optional, for droid firmware load helper
-CONFIG_FW_LOADER_USER_HELPER	y,!	# Required by droid firmware load helper
-CONFIG_HIDRAW			y,m,!	# optional: Support HID devices
-CONFIG_IKCONFIG_PROC		y	# Required by hybris-boot init-script
-CONFIG_INOTIFY_USER		y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_IP6_NF_MATCH_AH	y,m,!	# connman: for ip6tables ah match
-CONFIG_IP6_NF_MATCH_FRAG	y,m,!	# connman: for ip6tables frag match
-CONFIG_IP6_NF_MATCH_MH	y,m,!	# connman: for ip6tables mh match
-CONFIG_IP6_NF_MATCH_RPFILTER	y	# To be able to mitigate CVE-2019-14899 with ConnMan iptables rule
-CONFIG_IPC_NS			y	# Namespacing option needed by firejail
-CONFIG_IPC_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_IP_MULTIPLE_TABLES	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_IP_NF_IPTABLES		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_IP_NF_MATCH_AH	y,m,!	# connman: for iptables ah match
-CONFIG_IP_NF_MATCH_ECN	y,m,!	# connman: for iptables ecn match
-CONFIG_IP_NF_MATCH_RPFILTER	y	# Add to have both IPv4 and IPv6 RPFILTER matches set
-CONFIG_IP_NF_MATCH_TTL	y,m,!	# connman: for iptables ttl match
-CONFIG_IP_NF_TARGET_MASQUERADE	y,m,!   # connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
-CONFIG_IPV6			y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
-CONFIG_ISO9660_FS			y,m,!     # optional extra filesystem (CD-ROM)
-CONFIG_LBDAF			y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
-CONFIG_LOCKD_V4			y,!     # optional, for NFS support
-CONFIG_LOCKD			y,m,!     # optional, for NFS support
-CONFIG_MEMCG_KMEM		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
-CONFIG_MEMCG_SWAP		y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
-CONFIG_MEMCG			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if version >= 3.6
-CONFIG_MODULES			y,!	# optional, required for module support (Such as WLAN for example)
-CONFIG_NAMESPACES		y	# Namespacing is needed by firejail
-CONFIG_NET_CLS_CGROUP		y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NETFILTER_NETLINK_ACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_ANDROID_PARANOID_NETWORK		y,n       # Since Android 5 on some devices this flag is needed for rild to work. But it breaks connectivity in Sailfish OS if user nemo is not part of inet group. "y,n" switch means that this flag's presence/absence won't fail the checks anymore, but instead dhd will autodetect it and add nemo to inet
+CONFIG_AUDIT				y,!	# Required by SELinux. Can be disabled at boottime via kernel cmdline: audit=0. You can also leave audit enabled, if you don't plan to use systemd's containers: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
+CONFIG_AUTOFS4_FS			y,m,!	# systemd (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=713bc0cfa477ca1df8769041cb3dbc83c10eace2
+CONFIG_BLK_CGROUP			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_BLK_DEV_NBD			y,m,!	# optional, for NFS & CIFS support
+CONFIG_BRIDGE				y,m,!	# connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
+CONFIG_BT_BNEP_MC_FILTER		y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_BNEP_PROTO_FILTER		y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_BNEP				y,!	# Bluez (optional): Needed if bluetooth networking is wanted, e.g. for bluetooth tethering
+CONFIG_BT_HCIUART_H4			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BT_HCIUART			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BT_HCIVHCI			y,!	# Bluez (optional): Needed if bluebinder is used with bluez (Android 8+ based ports)
+CONFIG_BT_HIDP				y,!	# Bluez (optional): Needed for HIDP (Human Interface Device Protocol) transport layer
+CONFIG_BT_MSM_SLEEP			n,!	# Bluez (optional): Causes problems with bluez thus disabling is recommended.
+CONFIG_BT_RFCOMM			y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_BTRFS_FS				y,!	# optional extra filesystem (BTRFS)
+CONFIG_BT				y,!	# Bluez (optional): Needed if bluez used as bluetooth stack
+CONFIG_CGROUP_CPUACCT			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_DEVICE			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_FREEZER			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_MEM_RES_CTLR_KMEM		y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR_SWAP		y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_MEM_RES_CTLR		y,!,<=3.5	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version <= 3.5
+CONFIG_CGROUP_NET_PRIO			y,!,>=3.14	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_PERF			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUP_SCHED			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CGROUPS				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_CHECKPOINT_RESTORE		y,!	# rich-core-dumper (https://github.com/mer-tools/sp-rich-core/) needs this to collect all data for environment recreation.
+CONFIG_CIFS				y,m,!	# optional extra filesystem (CIFS - Windows net fs)
+CONFIG_CPUSETS				y,m,!	# lxc (optional): required to run lxc containers
+CONFIG_CUSE				y,!,>=2.6	# CUSE (optional): Required for software security modules support.
+CONFIG_DEVTMPFS_MOUNT			y	# Required by hybris-boot init-script
+CONFIG_DEVTMPFS				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_DUMMY				n
+CONFIG_ECRYPT_FS			y,m,!	# optional extra filesystem (ecryptfs)
+CONFIG_EPOLL				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_EXT4_FS				y,m,!	# Mer uses ext4 as rootfs by default
+CONFIG_F2FS_FS_SECURITY			y,m,!	# required to mount f2fs volumes under SELinux
+CONFIG_F2FS_FS				y,m,!	# optional extra filesystem (f2fs - a good SD filesystem)
+CONFIG_FANOTIFY				y,!	# optional, required for systemd readahead.
+CONFIG_FHANDLE				y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=001809282918f273d372f1ee09d10b783c18a474
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK	y,!	# optional, for droid firmware load helper
+CONFIG_FW_LOADER_USER_HELPER		y,!	# Required by droid firmware load helper
+CONFIG_HIDRAW				y,m,!	# optional: Support HID devices
+CONFIG_IKCONFIG_PROC			y	# Required by hybris-boot init-script
+CONFIG_INOTIFY_USER			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_IP6_NF_MATCH_AH			y,m,!	# connman: for ip6tables ah match
+CONFIG_IP6_NF_MATCH_FRAG		y,m,!	# connman: for ip6tables frag match
+CONFIG_IP6_NF_MATCH_MH			y,m,!	# connman: for ip6tables mh match
+CONFIG_IP6_NF_MATCH_RPFILTER		y	# To be able to mitigate CVE-2019-14899 with ConnMan iptables rule
+CONFIG_IPC_NS				y	# Namespacing option needed by firejail
+CONFIG_IPC_NS				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_IP_MULTIPLE_TABLES		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_IPTABLES			y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
+CONFIG_IP_NF_MATCH_AH			y,m,!	# connman: for iptables ah match
+CONFIG_IP_NF_MATCH_ECN			y,m,!	# connman: for iptables ecn match
+CONFIG_IP_NF_MATCH_RPFILTER		y	# Add to have both IPv4 and IPv6 RPFILTER matches set
+CONFIG_IP_NF_MATCH_TTL			y,m,!	# connman: for iptables ttl match
+CONFIG_IP_NF_TARGET_MASQUERADE		y,m,!	# connman (optional): support tethering, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=19fe7cad485afa6a7a5cc4aa75615ce8b7b8d376
+CONFIG_IPV6				y,m,!	# systemd: http://cgit.freedesktop.org/systemd/systemd/tree/README#n37
+CONFIG_ISO9660_FS			y,m,!	# optional extra filesystem (CD-ROM)
+CONFIG_LBDAF				y,!	# ext4 filesystem requires this in order to support filesysetms with huge_file feature, which is enabled by default by mke2fs.ext4, not needed for 64bit architectures
+CONFIG_LOCKD_V4				y,!	# optional, for NFS support
+CONFIG_LOCKD				y,m,!	# optional, for NFS support
+CONFIG_MEMCG_KMEM			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_MEMCG_SWAP			y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if kernel version >= 3.6
+CONFIG_MEMCG				y,!,>=3.6	# systemd (optional, but recommended): https://github.com/systemd/systemd/blob/v238/README, only valid if version >= 3.6
+CONFIG_MODULES				y,!	# optional, required for module support (Such as WLAN for example)
+CONFIG_NAMESPACES			y	# Namespacing is needed by firejail
+CONFIG_NET_CLS_CGROUP			y,!	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NETFILTER_NETLINK_ACCT		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
 CONFIG_NETFILTER_XT_CONNMARK		y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
 CONFIG_NETFILTER_XT_MATCH_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
 CONFIG_NETFILTER_XT_MATCH_CONNTRACK	y	# connman: for iptables conntrack match
-CONFIG_NETFILTER_XT_MATCH_DCCP	y,m,!	# connman: for iptables dccp match
-CONFIG_NETFILTER_XT_MATCH_ESP	y,m,!	# connmman: for iptables esp match
+CONFIG_NETFILTER_XT_MATCH_DCCP		y,m,!	# connman: for iptables dccp match
+CONFIG_NETFILTER_XT_MATCH_ESP		y,m,!	# connmman: for iptables esp match
 CONFIG_NETFILTER_XT_MATCH_HASHLIMIT	y,m,!	# connman: for iptables hashlimit match
 CONFIG_NETFILTER_XT_MATCH_HELPER	y,m,!	# connman: for iptables helper match
 CONFIG_NETFILTER_XT_MATCH_IPRANGE	y,m,!	# connman: for iptables iprange match
-CONFIG_NETFILTER_XT_MATCH_LIMIT	y,m,!	# connman: for iptables limit match
-CONFIG_NETFILTER_XT_MATCH_MARK	y,m,!	# connman: for iptables mark match
+CONFIG_NETFILTER_XT_MATCH_LIMIT		y,m,!	# connman: for iptables limit match
+CONFIG_NETFILTER_XT_MATCH_MARK		y,m,!	# connman: for iptables mark match
 CONFIG_NETFILTER_XT_MATCH_MULTIPORT	y	# connman: for iptables multiple port match
 CONFIG_NETFILTER_XT_MATCH_NFACCT	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=41f37125887cb9208da2441e350e1e3324c17ee6
-CONFIG_NETFILTER_XT_MATCH_OWNER	y,m,>=4.14.0	# connman: for iptables owner match
+CONFIG_NETFILTER_XT_MATCH_OWNER		y,m,>=4.14.0	# connman: for iptables owner match
 CONFIG_NETFILTER_XT_MATCH_PKTTYPE	y,m,!	# connman: for iptables pkttype match
-CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0 # connman: for iptables owner/qtaguid match, deprecated after Android Q, non-mainline feature https://android.googlesource.com/kernel/configs/+/189cbab05f8680af3778b82a0b899485773e42e9%5E%21/android-4.14/android-base.config
+CONFIG_NETFILTER_XT_MATCH_QTAGUID	y,m,<=4.13.0	# connman: for iptables owner/qtaguid match, deprecated after Android Q, non-mainline feature https://android.googlesource.com/kernel/configs/+/189cbab05f8680af3778b82a0b899485773e42e9%5E%21/android-4.14/android-base.config
 CONFIG_NETFILTER_XT_MATCH_RECENT	y,m,!	# connman: for iptables recent match
-CONFIG_NETFILTER_XT_MATCH_SCTP	y,m,!	# connman: for iptables sctp match
-CONFIG_NETFILTER_XT_MATCH_STATE	y,m,!	# connman: for iptables state match
+CONFIG_NETFILTER_XT_MATCH_SCTP		y,m,!	# connman: for iptables sctp match
+CONFIG_NETFILTER_XT_MATCH_STATE		y,m,!	# connman: for iptables state match
 CONFIG_NETFILTER_XT_TARGET_CONNMARK	y,m,!	# connman (optional): for routing and statistic support in sessions, http://git.kernel.org/cgit/network/connman/connman.git/commit/README?id=115cb9cbd3cdda00784e58a4ea12b42d128732b4
-CONFIG_NET_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_NETPRIO_CGROUP		y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
-CONFIG_NETWORK_FILESYSTEMS	y,!     # optional, for NFS support
-CONFIG_NET			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
-CONFIG_NF_NAT_IPV6		y,m,!	# connman: to enable IPv6 NAT
-CONFIG_NFS_ACL_SUPPORT		y,m,!     # optional, for NFS support
-CONFIG_NFS_COMMON			y,!     # optional, for NFS support
-CONFIG_NFS_FS			y,m,!     # optional, for NFS support
-CONFIG_NFS_USE_KERNEL_DNS	y,!     # optional, for NFS support
-CONFIG_NFS_V3_ACL		y,!     # optional, for NFS support
-CONFIG_NFS_V3			y,!     # optional, for NFS support
-CONFIG_NFS_V4_1			y,!     # optional, for NFS support
-CONFIG_NFS_V4			y,!     # optional, for NFS support
-CONFIG_NLS_UTF8			y	# Ensure that we support UTF8 filenames.
-CONFIG_PID_NS			y	# Namespacing option needed by firejail
-CONFIG_PID_NS			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_PROC_FS			y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=06d461ee6f3da6650e6d023d7828455752d70b0b
-CONFIG_QFMT_V2			y	# Use this version of the interface for quotactl
-CONFIG_QUOTACTL			y	# To adjust quota
-CONFIG_QUOTA_NETLINK_INTERFACE	y	# For quota_nld service
-CONFIG_QUOTA			y	# Quota is needed to prevent additional users from taking all space
-CONFIG_RD_GZIP			y	# Required by hybris-boot Android.mk
-CONFIG_RFKILL			y,m,!	# (optional) Needed if bluebinder is used
-CONFIG_RTC_DRV_CMOS		y,!	# optional, but highly recommended, not available on arm64
-CONFIG_SCHED_DEBUG		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
-CONFIG_SCHEDSTATS		y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
-CONFIG_SECCOMP			y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
-CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE 0,! # Alternative way to disable SELinux at boottime
+CONFIG_NET_NS				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_NETPRIO_CGROUP			y,!,<=3.13	# systemd (optional): https://github.com/systemd/systemd/blob/v238/README
+CONFIG_NETWORK_FILESYSTEMS		y,!	# optional, for NFS support
+CONFIG_NET				y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=41938693e76c32161d2b3b83253ce996468cbf9b
+CONFIG_NF_NAT_IPV6			y,m,!	# connman: to enable IPv6 NAT
+CONFIG_NFS_ACL_SUPPORT			y,m,!	# optional, for NFS support
+CONFIG_NFS_COMMON			y,!	# optional, for NFS support
+CONFIG_NFS_FS				y,m,!	# optional, for NFS support
+CONFIG_NFS_USE_KERNEL_DNS		y,!	# optional, for NFS support
+CONFIG_NFS_V3_ACL			y,!	# optional, for NFS support
+CONFIG_NFS_V3				y,!	# optional, for NFS support
+CONFIG_NFS_V4_1				y,!	# optional, for NFS support
+CONFIG_NFS_V4				y,!	# optional, for NFS support
+CONFIG_NLS_UTF8				y	# Ensure that we support UTF8 filenames.
+CONFIG_PID_NS				y	# Namespacing option needed by firejail
+CONFIG_PID_NS				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_PROC_FS				y	# systemd: http://cgit.freedesktop.org/systemd/systemd/commit/README?id=06d461ee6f3da6650e6d023d7828455752d70b0b
+CONFIG_QFMT_V2				y	# Use this version of the interface for quotactl
+CONFIG_QUOTACTL				y	# To adjust quota
+CONFIG_QUOTA_NETLINK_INTERFACE		y	# For quota_nld service
+CONFIG_QUOTA				y	# Quota is needed to prevent additional users from taking all space
+CONFIG_RD_GZIP				y	# Required by hybris-boot Android.mk
+CONFIG_RFKILL				y,m,!	# (optional) Needed if bluebinder is used
+CONFIG_RTC_DRV_CMOS			y,!	# optional, but highly recommended, not available on arm64
+CONFIG_SCHED_DEBUG			y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
+CONFIG_SCHEDSTATS			y,!	# systemd-bootchart (optional): http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f1c24fea94e19cf2108abbeed1d36ded7102ab98
+CONFIG_SECCOMP				y,!	# systemd (optional): strongly recommended, http://cgit.freedesktop.org/systemd/systemd/commit/README?id=f28cbd0382ca53baa99803bbc907a469fbf68128
+CONFIG_SECURITY_SELINUX_BOOTPARAM_VALUE	0,!	# Alternative way to disable SELinux at boottime
 CONFIG_SECURITY_SELINUX_BOOTPARAM	y,!	# Up to hybris-16 it's recommended to have SELinux disabled at boottime via kernel cmdline: selinux=0 or SECURITY_SELINUX_BOOTPARAM_VALUE=0. For hybris-17 SELinux should be left enabled.
-CONFIG_SECURITY_SELINUX		y,!	# Most hybris adaptations must have SELinux builtin in kernel
-CONFIG_SECURITY_YAMA_STACKED	y,!,<4.3     # optional, only valid for kernel < 4.3
-CONFIG_SECURITY_YAMA		y,!     # optional, prevents user's processes from ptracing each other
-CONFIG_SIGNALFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_SUNRPC_GSS			y,m,!     # optional, for NFS support
-CONFIG_SUNRPC			y,m,!     # optional, for NFS support
-CONFIG_SYSFS_DEPRECATED		n	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_SYSFS			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_SYSVIPC			y	# Inter Process Communication option is required to run Mer
-CONFIG_TIMERFD			y	# systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_TMPFS_POSIX_ACL		y	# systemd: required by hybris-boot init-script, if you want pam_systemd.so to setup your "seats". http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
-CONFIG_TMPFS_XATTR		y,!	# systemd (optional): strongly recommended, https://github.com/systemd/systemd/blob/v238/README
-CONFIG_TUN                      y,m,!   # ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
-CONFIG_UDF_FS			y,m,!     # optional extra filesystem (DVD & portable USB)
-CONFIG_UEVENT_HELPER_PATH	"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
-CONFIG_UNIX			y	# UNIX sockets option is required to run Mer
-CONFIG_UTS_NS			y	# Namespacing option needed by firejail
-CONFIG_UTS_NS 			y,!	# optional, enables kernel namespaces for systemd-nspawn containers
-CONFIG_VT			y	# Required for virtual consoles
-CONFIG_WATCHDOG_NOWAYOUT	y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.
+CONFIG_SECURITY_SELINUX			y,!	# Most hybris adaptations must have SELinux builtin in kernel
+CONFIG_SECURITY_YAMA_STACKED		y,!,<4.3	# optional, only valid for kernel < 4.3
+CONFIG_SECURITY_YAMA			y,!	# optional, prevents user's processes from ptracing each other
+CONFIG_SIGNALFD				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SUNRPC_GSS			y,m,!	# optional, for NFS support
+CONFIG_SUNRPC				y,m,!	# optional, for NFS support
+CONFIG_SYSFS_DEPRECATED			n	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SYSFS				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_SYSVIPC				y	# Inter Process Communication option is required to run Mer
+CONFIG_TIMERFD				y	# systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_TMPFS_POSIX_ACL			y	# systemd: required by hybris-boot init-script, if you want pam_systemd.so to setup your "seats". http://cgit.freedesktop.org/systemd/systemd/commit/README?id=77b6e19458f37cfde127ec6aa9494c0ac45ad890
+CONFIG_TMPFS_XATTR			y,!	# systemd (optional): strongly recommended, https://github.com/systemd/systemd/blob/v238/README
+CONFIG_TUN				y,m,!	# ofono: http://git.kernel.org/?p=network/ofono/ofono.git;a=blob;f=README;h=413d789e5f9e96024986f5116d3c8aff0c9f15b8;hb=HEAD#l28
+CONFIG_UDF_FS				y,m,!	# optional extra filesystem (DVD & portable USB)
+CONFIG_UEVENT_HELPER_PATH		"", !	# should be empty, if you want to use systemd without initramfs. Also systemd: https://github.com/systemd/systemd/blob/v238/README
+CONFIG_UNIX				y	# UNIX sockets option is required to run Mer
+CONFIG_UTS_NS				y	# Namespacing option needed by firejail
+CONFIG_UTS_NS 				y,!	# optional, enables kernel namespaces for systemd-nspawn containers
+CONFIG_VT				y	# Required for virtual consoles
+CONFIG_WATCHDOG_NOWAYOUT		y,!	# If device uses watchdogs with dsme (https://github.com/sailfishos/dsme), this option should be enabled or watchdog does not protect the device in case dsme crashes.


### PR DESCRIPTION
Add some network related configs based on cross referring between X10 II and III kernel configs. Mainly to ensure that we would not miss some important ones in the future.